### PR TITLE
Add build GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: build
+on:
+  workflow_dispatch:
+  push:
+jobs:
+  build:
+    name: Build
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { os: macos-latest , target: x86_64-apple-darwin, file: albw-randomizer }
+          - { os: macos-latest , target: aarch64-apple-darwin, file: albw-randomizer }
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-musl, file: albw-randomizer }
+          - { os: ubuntu-latest, target: aarch64-unknown-linux-musl, file: albw-randomizer }
+          - { os: windows-latest, target: x86_64-pc-windows-gnu, file: albw-randomizer.exe }
+          - { os: windows-latest, target: aarch64-pc-windows-msvc, file: albw-randomizer.exe }
+    runs-on: ${{ matrix.platform.os }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Install musl dependencies
+        if: ${{ matrix.platform.os == 'ubuntu-latest' }}
+        run: sudo apt install -y musl-tools
+      - name: Cargo build program
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: build
+          target: ${{ matrix.platform.target }}
+          args: "--release --bin albw-randomizer"
+          strip: true
+      - name: Prepare zip file
+        run: |
+          mkdir generated
+          touch generated/.keep
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.platform.target }}
+          path: |
+            target/${{ matrix.platform.target }}/release/${{ matrix.platform.file }}
+            config.json
+            generated
+            presets

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
           strip: true
       - name: Prepare zip file
         run: |
+          mv target/${{ matrix.platform.target }}/release/${{ matrix.platform.file }} .
           mkdir generated
           touch generated/.keep
       - name: Upload build artifact
@@ -38,7 +39,7 @@ jobs:
         with:
           name: ${{ matrix.platform.target }}
           path: |
-            target/${{ matrix.platform.target }}/release/${{ matrix.platform.file }}
+            ${{ matrix.platform.file }}
             config.json
             generated
             presets

--- a/rom/Cargo.toml
+++ b/rom/Cargo.toml
@@ -17,7 +17,7 @@ log = { workspace = true }
 once_cell = "1.18.0"
 path-absolutize = { workspace = true }
 regex = "1.9.3"
-ring = "0.17.0-alpha.11"
+ring = "0.17.0"
 serde = { workspace = true }
 serde_repr = "0.1.16"
 yaz0 = { workspace = true }


### PR DESCRIPTION
Sets up an Actions workflow for automatic builds of all pushed commits.

- Runs on any repo with the workflow file, so won't build other branches unless workflow is added to them
- Builds for x86_64 and aarch64 for Windows, macOS, and Linux
- Bumps ring so aarch64 Windows builds work