### PR TITLE
fix incorrect chest UNQs, fix TR key logic

### DIFF
--- a/randomizer/src/regions/dungeons/desert.rs
+++ b/randomizer/src/regions/dungeons/desert.rs
@@ -13,9 +13,9 @@ crate::region! {
             "[DP] (1F) Big Chest (Behind Wall)": PowerfulGlove @BigChest(1[70]),
 
             "[DP] (2F) Under Rock (Left)": RupeeSilver @Chest(2[550]),
-            "[DP] (2F) Beamos Room": RupeeSilver @Chest(2[545]),
+            "[DP] (2F) Beamos Room": RupeeSilver @Chest(2[276]),
             "[DP] (2F) Under Rock (Right)": RupeeSilver @Chest(2[548]),
-            "[DP] (2F) Under Rock (Ball Room)": RupeeSilver @Chest(2[276]),
+            "[DP] (2F) Under Rock (Ball Room)": RupeeSilver @Chest(2[545]),
             "[DP] (2F) Big Chest (Puzzle)": KeyBoss @BigChest(2[35]),
             "[DP] (2F) Red/Blue Switches": KeySmall @Chest(2[462]),
 

--- a/randomizer/src/regions/dungeons/swamp.rs
+++ b/randomizer/src/regions/dungeons/swamp.rs
@@ -12,9 +12,9 @@ crate::region! {
             "[SP] (B1) Waterfall Room": KeySmall @Key(2[219]),
             "[SP] (B1) Big Chest (Secret)": ClothesBlue @BigChest(2[220]),
 
-            "[SP] (1F) Water Puzzle": KeySmall @Chest(1[373]),
-            "[SP] (1F) East Room": KeySmall @Chest(1[299]),
-            "[SP] (1F) West Room": LiverPurple @Chest(1[170]),
+            "[SP] (1F) Water Puzzle": KeySmall @Chest(1[299]),
+            "[SP] (1F) East Room": KeySmall @Chest(1[170]),
+            "[SP] (1F) West Room": LiverPurple @Chest(1[373]),
             "[SP] (1F) Big Chest (Fire)": KeyBoss @BigChest(1[28]),
 
             "[SP] Arrghus": HeartContainer @Heart(1[129]),

--- a/randomizer/src/world/hyrule.rs
+++ b/randomizer/src/world/hyrule.rs
@@ -100,7 +100,7 @@ pub(crate) fn graph(crack_map: &CrackMap) -> HashMap<Location, LocationNode> {
                         "Hyrule Hotfoot 65s",
                         regions::hyrule::lost::woods::SUBREGION => {
                             normal: | p | p.has_boots(),
-                            hard: |p| p.can_merge() && p.has_bell() && !p.cracksanity(),
+                            hard: |p| p.can_merge() && p.has_bell() && p.are_cracks_open() && !p.cracksanity(),
                             hell: |_| true, // Can just walk it
                         }
                     ),

--- a/randomizer/src/world/turtle.rs
+++ b/randomizer/src/world/turtle.rs
@@ -80,8 +80,8 @@ pub(crate) fn graph() -> HashMap<Location, LocationNode> {
                     ),
                     old_check(
                         LocationInfo::new("[TR] (B1) Big Chest (Top)", regions::dungeons::turtle::rock::SUBREGION),
-                        Some(|p| p.has_turtle_keys(1) && p.can_merge() && p.can_hit_shielded_switch()),
-                        Some(|p| (p.has_turtle_keys(1) && p.can_merge())), // hit switch with pots
+                        Some(|p| p.has_turtle_keys(3) && p.can_merge() && p.can_hit_shielded_switch()),
+                        Some(|p| (p.has_turtle_keys(3) && p.can_merge())), // hit switch with pots
                         None,
                         None,
                         None,

--- a/randomizer/src/world/turtle.rs
+++ b/randomizer/src/world/turtle.rs
@@ -80,8 +80,8 @@ pub(crate) fn graph() -> HashMap<Location, LocationNode> {
                     ),
                     old_check(
                         LocationInfo::new("[TR] (B1) Big Chest (Top)", regions::dungeons::turtle::rock::SUBREGION),
-                        Some(|p| p.has_turtle_keys(3) && p.can_merge() && p.can_hit_shielded_switch()),
-                        Some(|p| (p.has_turtle_keys(3) && p.can_merge())), // hit switch with pots
+                        Some(|p| p.has_turtle_keys(1) && p.can_merge() && p.can_hit_shielded_switch()),
+                        Some(|p| (p.has_turtle_keys(1) && p.can_merge())), // hit switch with pots
                         None,
                         None,
                         None,


### PR DESCRIPTION
This makes two small changes:
- Fixes a couple chests that have their unique ids swapped, so that the item that is supposed to go in one chest would instead go in the other.
- Fixes the key logic for the upper big chest in Turtle Rock, which should logically require 3 keys because the keys may be spent in other places.