### PR TITLE
v0.4.1 Bug Fixes

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -25,10 +25,8 @@ pub fn get_seed_settings() -> Result<Settings, String> {
 
     let logic_mode = prompt_logic_mode();
 
-    let dungeon_prize_shuffle = prompt_bool(
-        "Randomize Dungeon Prizes",
-        "This shuffles all Sage Portraits, Pendants, and the Charm among themselves.",
-    );
+    let dungeon_prize_shuffle =
+        prompt_bool("Randomize Dungeon Prizes", "This shuffles all Sage Portraits and Pendants amongst themselves.");
 
     let maiamai_limit =
         prompt_u8_in_range("Maiamai Limit", "Choose the maximum number of Maiamai you're willing to collect:", 0, 100)

--- a/presets/Example.json
+++ b/presets/Example.json
@@ -8,7 +8,7 @@
     "logic_mode":                  "Normal",                  // "Normal", "Hard", "Glitched", "AdvGlitched", "Hell", "NoLogic"
     "lc_requirement":              7,                         // Sage Portraits needed to enter Lorule Castle's front door.
     "ped_requirement":             "Standard",                // MS Pedestal Pendant requirement: (2) "Vanilla", (3) "Standard"
-    "dungeon_prize_shuffle":       true,                      // This shuffles all Sage Portraits and Pendants among themselves.
+    "dungeon_prize_shuffle":       true,                      // This shuffles all Sage Portraits and Pendants amongst themselves.
     "door_shuffle":                "DungeonEntrances",
     "cracks":                      "Closed",                  // "Closed", "Open"
     "cracksanity":                 "Off",                     // "Off", "CrossWorldPairs", "AnyWorldPairs", "MirroredCrossWorldPairs", "MirroredAnyWorldPairs"

--- a/presets/Example.json
+++ b/presets/Example.json
@@ -1,7 +1,7 @@
 {
   // "Visit the project GitHub for details about each option: https://github.com/rickfay/z17-randomizer/tree/dev#game-options"
   "seed": 0,
-  "version": "v0.4.1 - Beta Build 2025-03-25",
+  "version": "v0.4.1 - Beta Build 2025-03-26",
   "settings": {
 
 
@@ -9,7 +9,7 @@
     "lc_requirement":              7,                         // Sage Portraits needed to enter Lorule Castle's front door.
     "ped_requirement":             "Standard",                // MS Pedestal Pendant requirement: (2) "Vanilla", (3) "Standard"
     "dungeon_prize_shuffle":       true,                      // This shuffles all Sage Portraits and Pendants amongst themselves.
-    "door_shuffle":                "DungeonEntrances",
+    "door_shuffle":                "Off",                     // "Off", "DungeonEntrances"
     "cracks":                      "Closed",                  // "Closed", "Open"
     "cracksanity":                 "Off",                     // "Off", "CrossWorldPairs", "AnyWorldPairs", "MirroredCrossWorldPairs", "MirroredAnyWorldPairs"
     "keysy":                       "Off",                     // "Off", "SmallKeysy", "BigKeysy", "AllKeysy"

--- a/randomizer/src/constants.rs
+++ b/randomizer/src/constants.rs
@@ -1,5 +1,5 @@
 //! Application Constants
 
 /// Build Version
-pub const VERSION: &str = "v0.4.1 - Beta Build 2025-03-25";
+pub const VERSION: &str = "v0.4.1 - Beta Build 2025-03-26";
 pub const CONFIG_FILE_NAME: &str = "config.json";

--- a/randomizer/src/filler/item_pools.rs
+++ b/randomizer/src/filler/item_pools.rs
@@ -1,10 +1,10 @@
 use crate::SeedInfo;
 use crate::filler::cracks::Crack;
 use crate::filler::doors::Door;
-use crate::filler::filler_item::Item;
 use crate::filler::filler_item::Item::*;
 use crate::filler::filler_item::Vane;
 use crate::filler::filler_item::Vane::*;
+use crate::filler::filler_item::{Item, Randomizable};
 use crate::filler::util::shuffle;
 use modinfo::Settings;
 use modinfo::settings::cracks::Cracks;
@@ -24,7 +24,9 @@ pub type Pool = Vec<Item>;
  * The total number of items returned between both pools should match the total number of locations
  * in the world graph, including locations that statically set their contents.
  */
-pub(crate) fn get_item_pools(rng: &mut StdRng, SeedInfo { settings, .. }: &SeedInfo) -> (Pool, Pool) {
+pub(crate) fn get_item_pools(
+    rng: &mut StdRng, SeedInfo { settings, .. }: &SeedInfo,
+) -> (Pool, Pool, Vec<Randomizable>) {
     let mut progression_items = get_base_progression_pool();
     let minor_progression = get_minor_progression_pool();
     let dungeon_prizes = get_dungeon_prize_pool();
@@ -95,13 +97,15 @@ pub(crate) fn get_item_pools(rng: &mut StdRng, SeedInfo { settings, .. }: &SeedI
     let junk_pool = get_base_junk_pool();
     let mut junk_pool = shuffle(rng, junk_pool);
 
+    let mut removed_from_play = vec![];
+
     match extra_items_needed.cmp(&0) {
         // Add Energy Potions to the pool if we need extra items
         Ordering::Greater => (0..extra_items_needed).for_each(|_| junk_pool.push(EnergyPotion)),
         // Remove a random junk item from the pool if we have too many items
-        Ordering::Less => (0..-extra_items_needed).for_each(|_| {
-            junk_pool.pop();
-        }),
+        Ordering::Less => {
+            (0..-extra_items_needed).for_each(|_| removed_from_play.push(junk_pool.pop().unwrap().into()))
+        },
         Ordering::Equal => {},
     }
 
@@ -112,6 +116,7 @@ pub(crate) fn get_item_pools(rng: &mut StdRng, SeedInfo { settings, .. }: &SeedI
             dungeon_prizes, big_keys, small_keys, compasses, progression_items, minor_progression,
         ]),
         junk_pool,
+        removed_from_play,
     )
 }
 

--- a/randomizer/src/filler/mod.rs
+++ b/randomizer/src/filler/mod.rs
@@ -39,7 +39,8 @@ pub mod vanes;
 pub fn fill_all_locations_reachable(
     rng: &mut StdRng, seed_info: &mut SeedInfo, check_map: &mut CheckMap,
 ) -> crate::Result<()> {
-    let (mut progression_pool, mut junk_pool) = item_pools::get_item_pools(rng, seed_info);
+    let (mut progression_pool, mut junk_pool, removed_from_play) = item_pools::get_item_pools(rng, seed_info);
+    seed_info.removed_from_play = removed_from_play;
 
     place_cracks(seed_info, check_map);
     place_weather_vanes(seed_info, check_map);

--- a/randomizer/src/lib.rs
+++ b/randomizer/src/lib.rs
@@ -323,6 +323,9 @@ pub struct SeedInfo {
     pub full_exclusions: BTreeSet<String>,
 
     #[serde(skip_deserializing)]
+    pub removed_from_play: Vec<Randomizable>,
+
+    #[serde(skip_deserializing)]
     pub treacherous_tower_floors: Vec<TowerStage>,
 
     #[serde(skip_deserializing)]
@@ -367,6 +370,7 @@ impl Default for SeedInfo {
             hash: Default::default(),
             settings: Default::default(),
             full_exclusions: Default::default(),
+            removed_from_play: Default::default(),
             door_map: Default::default(),
             crack_map: Default::default(),
             vane_map: Default::default(),
@@ -532,6 +536,7 @@ fn calculate_seed_info(seed: u32, settings: Settings, hash: SeedHash, rng: &mut 
         hash,
         settings,
         full_exclusions: Default::default(),
+        removed_from_play: Default::default(),
         vane_map,
         crack_map,
         door_map,

--- a/randomizer/src/patch/prizes.rs
+++ b/randomizer/src/patch/prizes.rs
@@ -483,12 +483,12 @@ fn patch_dark(patcher: &mut Patcher, seed_info: &SeedInfo, prize: Randomizable) 
     //                 Obj::step_switch(Flag::Course(21), 4, 400, 400,
     //                                  Vec3 { x: 0.0, y: 0.0, z: -44.75 }));
 
+    let sp = get_dungeon_prize_spawn(DarkPalaceExit, &seed_info.door_map);
+    modify_dungeon_reward(patcher, prize, 262, DungeonDark, 1, false, sp);
+
     if prize == Item(SageGulley) {
         return;
     }
-
-    let sp = get_dungeon_prize_spawn(DarkPalaceExit, &seed_info.door_map);
-    modify_dungeon_reward(patcher, prize, 262, DungeonDark, 1, false, sp);
 
     if is_pendant(prize) {
         // Don't take camera control away from player to watch Mask break and reveal... nothing...
@@ -552,30 +552,18 @@ fn patch_dark(patcher: &mut Patcher, seed_info: &SeedInfo, prize: Randomizable) 
 
 /// Swamp Palace
 fn patch_swamp(patcher: &mut Patcher, seed_info: &SeedInfo, prize: Randomizable) {
-    if prize == Item(SageOren) {
-        return;
-    }
-
     let sp = get_dungeon_prize_spawn(SwampPalaceExit, &seed_info.door_map);
     modify_dungeon_reward(patcher, prize, 13, DungeonWater, 3, true, sp);
 }
 
 /// Skull Woods
 fn patch_skull(patcher: &mut Patcher, seed_info: &SeedInfo, prize: Randomizable) {
-    if prize == Item(SageSeres) {
-        return;
-    }
-
     let sp = get_dungeon_prize_spawn(SkullWoodsExit, &seed_info.door_map);
     modify_dungeon_reward(patcher, prize, 273, FieldDark, 1, true, sp);
 }
 
 /// Thieves' Hideout
 fn patch_thieves(patcher: &mut Patcher, prize: Randomizable) {
-    if prize == Item(SageOsfala) {
-        return;
-    }
-
     // Always put the player outside the Portrait House, even in Door Shuffle
     modify_dungeon_reward(patcher, prize, 3, IndoorDark, 15, true, SpawnPoint::new(FieldDark, 16, 14));
 }
@@ -591,16 +579,17 @@ fn patch_turtle(patcher: &mut Patcher, seed_info: &SeedInfo, prize: Randomizable
     //                 Obj::step_switch(Flag::Course(130), 0, 32, 100,
     //                                  Vec3 { x: 0.0, y: 5.0, z: -39.0 }));
 
+    const UNQ_PRIZE: u16 = 56;
+
+    let sp = get_dungeon_prize_spawn(TurtleRockExit, &seed_info.door_map);
+    modify_dungeon_reward(patcher, prize, UNQ_PRIZE, DungeonKame, 3, false, sp);
+
     if prize == Item(SageImpa) {
         return;
     }
 
-    const UNQ_PRIZE: u16 = 56;
     const DY: f32 = -2.0;
     const DZ: f32 = 0.5;
-
-    let sp = get_dungeon_prize_spawn(TurtleRockExit, &seed_info.door_map);
-    modify_dungeon_reward(patcher, prize, UNQ_PRIZE, DungeonKame, 3, false, sp);
 
     if is_pendant(prize) {
         // Pendants don't ride on the pillar, so manually move them and remove the pillar
@@ -650,12 +639,8 @@ fn patch_desert(patcher: &mut Patcher, seed_info: &SeedInfo, prize: Randomizable
     //                 Obj::step_switch(Flag::Course(252), 0, 58, 137,
     //                                  Vec3 { x: -19.0, y: 0.0, z: -19.0 }));
 
-    if prize == Item(SageIrene) {
-        return;
-    }
-
-    // When DoorShuffle is enabled have the DP prize and blue warp send the player to outside the
-    // dungeon's entrance, but otherwise keep the vanilla behavior of sending them to the Mire WV.
+    // When DoorShuffle is enabled have the DP prize send the player to outside the dungeon's
+    // entrance, but otherwise keep the vanilla behavior of sending them to the Mire WV.
     let sp = if seed_info.settings.door_shuffle != DoorShuffle::Off {
         get_dungeon_prize_spawn(DesertPalaceExit, &seed_info.door_map)
     } else {
@@ -663,6 +648,10 @@ fn patch_desert(patcher: &mut Patcher, seed_info: &SeedInfo, prize: Randomizable
     };
 
     modify_dungeon_reward(patcher, prize, 76, FieldDark, 31, true, sp);
+
+    if prize == Item(SageIrene) {
+        return;
+    }
 
     let prize_flag = prize_flag(prize);
     patcher.modify_objs(FieldDark, 31, [
@@ -680,12 +669,22 @@ fn patch_ice(patcher: &mut Patcher, seed_info: &SeedInfo, prize: Randomizable) {
     //     }),
     // ]);
 
-    if prize == Item(SageRosso) {
-        return;
-    }
-
     let sp = get_dungeon_prize_spawn(IceRuinsExit, &seed_info.door_map);
     modify_dungeon_reward(patcher, prize, 16, DungeonIce, 1, true, sp);
+
+    // Remove old trigger in dungeon
+    patcher.modify_objs(DungeonIce, 1, [disable(942)]);
+
+    // Add trigger overlapping loading zone to set Flag 610 to clear the entrance blocker
+    patcher.add_obj(
+        FieldDark,
+        5,
+        Obj::trigger_cube(Flag::Event(610), 0, 18, 34, Transform {
+            scale: Vec3 { x: 2.0, y: 2.0, z: 2.0 },
+            rotate: Vec3::ZERO,
+            translate: Vec3 { x: 0.5, y: 9.5, z: -3.5 },
+        }),
+    );
 }
 
 fn get_dungeon_prize_spawn(exit: Door, door_map: &DoorMap) -> SpawnPoint {


### PR DESCRIPTION
- Fix vanilla prizes not redirecting to the correct entrances in Dungeon ER
- Add "removed_from_play" section to spoiler log listing any items taken out of the pool
- Fix old Dungeon Prize Shuffle text to not mention the Charm